### PR TITLE
Fix package names in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,8 @@ htmlcov
 .envrc
 
 **/__pycache__/
+
+.venv
+venv
+.last_execution
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ htmlcov
 venv
 .last_execution
 *~
+.vscode

--- a/README.org
+++ b/README.org
@@ -8,9 +8,8 @@ Small utility to track the dependencies of the [[https://build.opensuse.org/proj
 zypper install python3-poetry libffi-devel
 git clone git@github.com:openSUSE/lubed
 cd lubed
-python3 -m venv .venv
-. .venv/bin/activate
 poetry install
+poetry shell
 #+end_src
 
 * Configuration

--- a/README.org
+++ b/README.org
@@ -4,9 +4,14 @@ Small utility to track the dependencies of the [[https://build.opensuse.org/proj
 
 
 * Installation
-1. ~zypper install python3-poetry~
-2. ~git clone git@github.com:agraul/lubed~
-3. ~poetry install~
+#+begin_src shell
+zypper install python3-poetry libffi-devel
+git clone git@github.com:openSUSE/lubed
+cd lubed
+python3 -m venv .venv
+. .venv/bin/activate
+poetry install
+#+end_src
 
 * Configuration
 ~lubed~ needs to know where to find the origin of the dependencies.

--- a/config.toml
+++ b/config.toml
@@ -64,13 +64,13 @@ project = "SUSE:SLE-15-SP4:Update"
 package = "python-cryptography"
 [origins.saltbundlepy-cryptography-vectors]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-vectors"
+package = "python3-cryptography-vectors"
 [origins.saltbundlepy-cssselect]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-cssselect"
 [origins.saltbundlepy-cython]
 project = "openSUSE:Factory"
-package = "python-cython"
+package = "python-Cython"
 [origins.saltbundlepy-distro]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-distro"
@@ -78,8 +78,8 @@ package = "python-distro"
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-docker"
 [origins.saltbundlepy-docker-pycreds]
-project = "SUSE:SLE-15-SP4:Update"
-package = "python-pycreds"
+project = "openSUSE:Factory"
+package = "python-docker-pycreds"
 [origins.saltbundlepy-docopt]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-docopt"
@@ -88,25 +88,28 @@ project = "SUSE:SLE-15-SP4:Update"
 package = "python-idna"
 [origins.saltbundlepy-importlib-metadata]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-metadata"
+package = "python-importlib-metadata"
 [origins.saltbundlepy-jinja2]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-jinja2"
+package = "python-Jinja2"
 [origins.saltbundlepy-kiwi]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-kiwi"
+[origins.saltbundlepy-libvirt]
+project = "SUSE:SLE-15-SP4:Update"
+package = "python-libvirt-python"
 [origins.saltbundlepy-lxml]
 project = "openSUSE:Factory"
 package = "python-lxml"
 [origins.saltbundlepy-m2crypto]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-m2crypto"
+package = "python3-M2Crypto"
 [origins.saltbundlepy-markupsafe]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-markupsafe"
+package = "python-MarkupSafe"
 [origins.saltbundlepy-more-itertools]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-itertools"
+package = "python-more-itertools"
 [origins.saltbundlepy-msgpack]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-msgpack"
@@ -139,7 +142,7 @@ project = "SUSE:SLE-15-SP4:Update"
 package = "python-pyasn1"
 [origins.saltbundlepy-pyasn1-modules]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-modules"
+package = "python-pyasn1-modules"
 [origins.saltbundlepy-pycparser]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-pycparser"
@@ -151,16 +154,19 @@ project = "SUSE:SLE-15-SP4:Update"
 package = "python-pyinotify"
 [origins.saltbundlepy-pynacl]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-pynacl"
+package = "python-PyNaCl"
 [origins.saltbundlepy-pyopenssl]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-pyopenssl"
+package = "python-pyOpenSSL"
+[origins.saltbundle-openssl]
+project = "SUSE:SLE-12-SP5:Update"
+package = "openssl"
 [origins.saltbundlepy-pyparsing]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-pyparsing"
 [origins.saltbundlepy-pysocks]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-pysocks"
+package = "python-PySocks"
 [origins.saltbundlepy-pytest]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-pytest"
@@ -172,7 +178,7 @@ project = "openSUSE:Factory"
 package = "python-pyxattr"
 [origins.saltbundlepy-pyyaml]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-pyyaml"
+package = "python-PyYAML"
 [origins.saltbundlepy-pyzmq]
 project = "openSUSE:Factory"
 package = "python-pyzmq"
@@ -181,16 +187,13 @@ project = "SUSE:SLE-15-SP4:Update"
 package = "python-requests"
 [origins.saltbundlepy-rpm-macros]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-macros"
-[origins.saltbundlepy-rpm-vercmp]
-project = "SUSE:SLE-15-SP4:Update"
-package = "python-vercmp"
+package = "python-rpm-macros"
 [origins.saltbundlepy-setuptools]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-setuptools"
 [origins.saltbundlepy-setuptools-scm]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-scm"
+package = "python-setuptools_scm"
 [origins.saltbundlepy-simplejson]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-simplejson"
@@ -203,15 +206,15 @@ package = "python-tornado"
 [origins.saltbundlepy-urllib3]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-urllib3"
-[origins.saltbundlepy-venvjail]
-project = "SUSE:SLE-15-SP4:Update"
-package = "python-venvjail"
+[origins.saltbundlepy-wcwidth]
+project = "SUSE:SLE-15-SP5:Update"
+package = "python-wcwidth"
 [origins.saltbundlepy-websocket-client]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-client"
+package = "python-websocket-client"
 [origins.saltbundlepy-zipp]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-zipp"
 [origins.saltbundlepy-zypp-plugin]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python-plugin"
+package = "zypp-plugin"

--- a/src/lubed/cli.py
+++ b/src/lubed/cli.py
@@ -200,17 +200,15 @@ def updates(last_timestamp_file, config_path, no_update_timestamp) -> None:
     now = Timestamp(time.time())
 
     with console.status("Checking for updates...", spinner="arc"):
-        updates = _calculate_updated_packages(
+        updates, failures = _calculate_updated_packages(
             last_timestamp, origins, credentials, api_url
         )
 
-    table = rich.table.Table(title="Packages Updated in Origin")
-    table.add_column("Bundle Package Name")
-    table.add_column("Origin Project Name")
-    table.add_column("Origin Package Name")
-    for updated_package in updates:
-        table.add_row(*updated_package)
-    console.print(table)
+    cols = ["Bundle Package Name", "Origin Project Name", "Origin Package Name"]
+    _print_table("Packages Updated in Origin", cols, updates)
+
+    if bool(failures):
+        _print_table("Packages that Failed to Check", cols, failures)
 
     _maybe_update_timestamp(no_update_timestamp, last_timestamp_file, now)
 
@@ -274,7 +272,7 @@ def create_issue(last_timestamp_file, config_path, gh_token, no_update_timestamp
         exit(4)
 
     with console.status("Checking for updates...", spinner="arc"):
-        updates = _calculate_updated_packages(
+        updates, failures = _calculate_updated_packages(
             last_timestamp, origins, credentials, api_url
         )
 
@@ -286,6 +284,12 @@ def create_issue(last_timestamp_file, config_path, gh_token, no_update_timestamp
     )
     rows = [f"|{bundle}|{project}|{package}|" for bundle, project, package in updates]
     updates_str = updates_header + "\n".join(rows)
+
+    if bool(failures):
+        rows = [f"|{bundle}|{project}|{package}|" for bundle, project, package in failures]
+        updates_str += '\n\n' + "Failed to check the following packages:\n"
+        updates_str += updates_header
+        updates_str += "\n".join(rows)
 
     issue_body = issue_body_template.substitute(
         {
@@ -311,16 +315,20 @@ def create_issue(last_timestamp_file, config_path, gh_token, no_update_timestamp
 
 def _calculate_updated_packages(last_execution, origins, credentials, api_url):
     updates = []
+    failures = []
     packages = {
         bundle_name: Package(project=p["project"], name=p["package"])
         for bundle_name, p in origins.items()
     }
 
     for bundle_name, package in packages.items():
-        if obs.package_was_updated(last_execution, package, credentials, api_url):
+        updated, err = obs.package_was_updated(last_execution, package, credentials, api_url)
+        if err:
+            failures.append((bundle_name, package.project, package.name))
+        elif updated:
             updates.append((bundle_name, package.project, package.name))
 
-    return updates
+    return updates, failures
 
 
 def _maybe_update_timestamp(no_update_timestamp, last_timestamp_file, current_time):
@@ -329,3 +337,14 @@ def _maybe_update_timestamp(no_update_timestamp, last_timestamp_file, current_ti
 
     with open(last_timestamp_file, "w") as f:
         f.write(str(current_time))
+
+
+def _print_table(title: str, columns: list, rows: list):
+    table = rich.table.Table(title=title)
+    for col in columns:
+        table.add_column(col)
+
+    for row in rows:
+        table.add_row(*row)
+
+    console.print(table)

--- a/src/lubed/cli.py
+++ b/src/lubed/cli.py
@@ -31,10 +31,13 @@ def cli():
 )
 def init(last_timestamp_file, force):
     """Initialize the last-timestamp-file with the current time."""
-    with open(last_timestamp_file, "r") as f:
-        if f.read() and not force:
-            console.print(f"Use --force to override {last_timestamp_file}.")
-            exit(3)
+    try:
+        with open(last_timestamp_file, "r") as f:
+            if f.read() and not force:
+                console.print(f"Use --force to override {last_timestamp_file}.")
+                exit(3)
+    except FileNotFoundError:
+        ...
     now = Timestamp(time.time())
     with open(last_timestamp_file, "w") as f:
         f.write(str(now))

--- a/src/lubed/obs.py
+++ b/src/lubed/obs.py
@@ -36,7 +36,7 @@ def package_was_updated(
     package: Package,
     credentials: OBSCredentials,
     api_url: str = "https://api.opensuse.org",
-) -> bool:
+) -> (bool, bool):
     """Check if an OBS package was changed since a known timestamp.
 
     :param last_check: Unix timestamp of the last check
@@ -45,7 +45,7 @@ def package_was_updated(
     :param api_url: Base URL of the OBS API server, defaults to https://api.opensuse.org
     :return: True if the package was updated, False otherwise
     """
-    response_text = _query_package(
+    response_text, err = _query_package(
         package=package,
         credentials=credentials,
         api_url=api_url,
@@ -53,7 +53,7 @@ def package_was_updated(
 
     timestamps = _extract_package_timestamps(response_text)
 
-    return _any_timestamp_is_newer(timestamps, last_check)
+    return _any_timestamp_is_newer(timestamps, last_check), err
 
 
 def list_subprojects(
@@ -80,11 +80,9 @@ def list_subprojects(
 def package_in_project(
     package_name: str, project_name: str, credentials: OBSCredentials, api_url: str
 ) -> bool:
-    return bool(
-        _query_package(
+    return _query_package(
             Package(name=package_name, project=project_name), credentials, api_url
-        )
-    )
+        )[1]
 
 
 @functools.lru_cache
@@ -148,11 +146,11 @@ def _query_package(
     package: Package,
     credentials: OBSCredentials,
     api_url: str,
-) -> str:
+) -> (str, bool):
     try:
         url = f"{api_url}/source/{package.project}/{package.name}"
         response = requests.get(url, auth=credentials.as_tuple())
         response.raise_for_status()
-        return response.text
+        return response.text, False
     except requests.RequestException:
-        return ""
+        return "", True

--- a/src/lubed/obs.py
+++ b/src/lubed/obs.py
@@ -43,7 +43,9 @@ def package_was_updated(
     :param package: OBS package to check
     :param credentials: OBS API credentials
     :param api_url: Base URL of the OBS API server, defaults to https://api.opensuse.org
-    :return: True if the package was updated, False otherwise
+    :return:
+        - package_updated: True if the package was updated, False otherwise
+        - err: True if an error occurred during the verification, False otherwise
     """
     response_text, err = _query_package(
         package=package,
@@ -81,8 +83,8 @@ def package_in_project(
     package_name: str, project_name: str, credentials: OBSCredentials, api_url: str
 ) -> bool:
     return _query_package(
-            Package(name=package_name, project=project_name), credentials, api_url
-        )[1]
+        Package(name=package_name, project=project_name), credentials, api_url
+    )[1]
 
 
 @functools.lru_cache


### PR DESCRIPTION
This PR includes several changes.

Functional changes: 

- Fixing error during first startup when timestamp file doesn't exist
- Changed behavior of silent failures; now, packages that fail the check are displayed on command line as well as the Github issue

Config changes:

- Fixing package names  

Misc changes:

- In readme, document that one of the Python dependencies requires the `libffi-devel` header files for C compilation
- In readme, document how to activate the poetry venv
- Extend gitignore