### PR TITLE
Add config for new Salt Bundle package: "saltbundlepy-dbus-python"

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -71,6 +71,9 @@ package = "python-cssselect"
 [origins.saltbundlepy-cython]
 project = "openSUSE:Factory"
 package = "python-Cython"
+[origins.saltbundlepy-dbus-python]
+project = "SUSE:SLE-15-SP6:Update"
+package = "python-dbus-python"
 [origins.saltbundlepy-distro]
 project = "SUSE:SLE-15-SP4:Update"
 package = "python-distro"


### PR DESCRIPTION
We added a new `saltbundlepy-dbus-python` package (already mentioned at https://github.com/openSUSE/salt/wiki/Salt-Bundle).

This PR just updates "lubed" configuration to get potential updates also for this package.