### PR TITLE
Bump the Python version to track to 3.11

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -25,7 +25,7 @@ labels = ["ion-squad", "salt-bundle"]
 [origins]
 [origins.saltbundlepy]
 project = "SUSE:SLE-15-SP4:Update"
-package = "python310"
+package = "python311"
 [origins.saltbundle-libsodium]
 project = "SUSE:SLE-15-SP4:Update"
 package = "libsodium"


### PR DESCRIPTION
This PR just adjusts the "lubed" configuration to track the current Python version we use in the Salt Bundle.